### PR TITLE
Subscription 타입 도입 & 식별자를 레퍼런스로 수정

### DIFF
--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1,8 +1,8 @@
-import { Store, Listener } from './store'
+import { Store, Listener, Subscription } from './store'
 
 describe('Store class', () => {
   describe('subscribe method', () => {
-    it('should add a listener to the listeners array', () => {
+    it('should add a listener to the subscription set', () => {
       const store = new Store(0)
       const listener = vitest.fn() as Listener<number> // Mock listener function
 
@@ -41,7 +41,7 @@ describe('Store class', () => {
   })
 
   describe('unsubscribe method', () => {
-    it('should remove a listener from the listeners array', () => {
+    it('should remove a listener by cleanup function', () => {
       const store = new Store(0)
       const listener1 = vitest.fn() as Listener<number>
       const listener2 = vitest.fn() as Listener<number>
@@ -67,36 +67,19 @@ describe('Store class', () => {
       ).toBeTruthy()
     })
 
-    it('should remove a listner by clean-up function', () => {
+    it('should do nothing if subscription is not found', () => {
       const store = new Store(0)
-      const listener1 = vitest.fn() as Listener<number>
-      const listener2 = vitest.fn() as Listener<number>
-
-      const unsub = store.subscribe(listener1)
-      store.subscribe(listener2)
-
-      expect(store.subscriptions.size).toBe(2)
-
-      unsub()
-
-      expect(store.subscriptions.size).toBe(1)
-      expect(
-        Array.from(store.subscriptions.values()).some(
-          ({ listener: l }) => listener1 === l
-        )
-      ).toBeFalsy()
-    })
-
-    it('should not modify the array if listener is not found', () => {
-      const store = new Store(0)
-      const listener1 = vitest.fn() as Listener<number>
-
-      store.subscribe(listener1)
+      const listener = vitest.fn() as Listener<number>
+      store.subscribe(listener)
 
       const originalSize = store.subscriptions.size
 
-      const nonExistentKey = Symbol()
-      store.unsubscribe(nonExistentKey)
+      const subscription: Subscription<number> = {
+        listener: vitest.fn() as Listener<number>,
+        selector: (v) => v,
+      }
+
+      store.unsubscribe(subscription)
 
       expect(store.subscriptions.size).toBe(originalSize)
     })

--- a/src/store.ts
+++ b/src/store.ts
@@ -4,13 +4,13 @@ type Selector<T> = (state: T) => any
 type Updater<T> = (state: T) => T
 type EqualityFn<T> = (a: T, b: T) => boolean
 
-interface Subscription<T> {
+export interface Subscription<T> {
   selector: Selector<T>
   listener: Listener<T>
 }
 
 export class Store<T> {
-  subscriptions: Map<symbol, Subscription<T>> = new Map()
+  subscriptions: Set<Subscription<T>> = new Set()
   state: T
   prevState: T
 
@@ -26,23 +26,16 @@ export class Store<T> {
   }
 
   subscribe(listener: Listener<T>, selector: Selector<T> = (v) => v) {
-    const key = Symbol()
+    const subscription = { listener, selector }
 
-    this.subscriptions.set(key, {
-      selector,
-      listener,
-    })
+    this.subscriptions.add(subscription)
 
-    // cleanup
-    return () => this.unsubscribe(key)
+    // cleanup by its own reference
+    return () => this.unsubscribe(subscription)
   }
 
-  unsubscribe(key: symbol) {
-    if (!this.subscriptions.has(key)) {
-      return
-    }
-
-    this.subscriptions.delete(key)
+  unsubscribe(subscription: Subscription<T>) {
+    this.subscriptions.delete(subscription)
   }
 
   getState(): T {


### PR DESCRIPTION
### Subscription - listener & selector 를 묶은 객체의 타입 정의

https://github.com/ReactMasters/state-manager/blob/46423fe5ebe6597b8a8fe1b9ed805b938edecd2d/src/store.ts#L7-L9

기존엔 object literal 로 되어 있었는데 `Subscription` 이라는 이름을 부여해주고 타입을 추가해줍니다.

https://github.com/ReactMasters/state-manager/blob/a48f42c21c18e7f97994205c1079eeed3ff67750/src/store.ts#L7-L10

### subscriptions (구 listeners) 를 Map -> Set 으로 변경

Map 구조는 클린업시 O(1)로 성능을 보장하지만, 불필요한 Symbol 키를 추가로 필요합니다.

https://github.com/ReactMasters/state-manager/blob/46423fe5ebe6597b8a8fe1b9ed805b938edecd2d/src/store.ts#L24-L34

클로저 안의 객체의 참조 그 자체를 사용하면 키처럼 사용할 수 있습니다.

https://github.com/ReactMasters/state-manager/blob/a48f42c21c18e7f97994205c1079eeed3ff67750/src/store.ts#L28-L35
https://github.com/ReactMasters/state-manager/blob/a48f42c21c18e7f97994205c1079eeed3ff67750/src/store.ts#L37-L39

더불어 Map의 구조로 달성했던 클린업 O(1)의 성능은 Set 으로 달성합니다.

https://github.com/ReactMasters/state-manager/blob/a48f42c21c18e7f97994205c1079eeed3ff67750/src/store.ts#L13
