### PR TITLE
vanilla api와 react adapter 분리

### DIFF
--- a/src/adapters/react.test.tsx
+++ b/src/adapters/react.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react'
-import { createStore, useReactive } from './react'
+import { useReactive } from './react'
+import { createStore } from '../vanilla'
 import { Mock } from 'vitest'
 import { Store } from '../store'
 

--- a/src/adapters/react.ts
+++ b/src/adapters/react.ts
@@ -1,9 +1,6 @@
 import { useSyncExternalStore } from 'react'
 import { Selector, Store } from '../store' // Store 클래스를 가져올 경로 지정
 
-export const createStore = <T>(defaultValue: T): Store<T> =>
-  new Store(defaultValue)
-
 export function useReactive<T, O = T>(
   store: Store<T>,
   selector: Selector<T, O> = (state) => state as unknown as O

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -1,0 +1,4 @@
+import { Store } from './store' // Store 클래스를 가져올 경로 지정
+
+export const createStore = <T>(defaultValue: T): Store<T> =>
+  new Store(defaultValue)


### PR DESCRIPTION
vanilla api와 react adapter를 분리합니다. 

### 변경사항
- `createStore`를 vanilla.ts 파일 생성 후 이동